### PR TITLE
Potential fix for code scanning alert no. 1: Clear-text logging of sensitive information

### DIFF
--- a/src/soundingcenter/SoundingCenter.py
+++ b/src/soundingcenter/SoundingCenter.py
@@ -11,6 +11,8 @@ class Api:
 
     def log(self, value):
         if self.logging:
+            if isinstance(value, dict) and "password" in value:
+                value = {**value, "password": "[REDACTED]"}
             print(value)
 
     def log_response(self, response: Response):
@@ -33,7 +35,10 @@ class Api:
         return request
 
     def post(self, path: str, json):
-        self.log(f"POST {self.base_url}/{path} {json}")
+        sanitized_json = {**json}
+        if "password" in sanitized_json:
+            sanitized_json["password"] = "[REDACTED]"
+        self.log(f"POST {self.base_url}/{path} {sanitized_json}")
 
         request = post(
             url=f"{self.base_url}/{path}",


### PR DESCRIPTION
Potential fix for [https://github.com/GrawRadiosondes/sounding-center-python-api/security/code-scanning/1](https://github.com/GrawRadiosondes/sounding-center-python-api/security/code-scanning/1)

To fix the issue, sensitive data such as passwords should be excluded from logging. This can be achieved by sanitizing the `value` argument before logging it. Specifically:
1. Modify the `log` method to check for sensitive data and redact it before printing.
2. Update the `log_response` and `post` methods to ensure sensitive data is not included in the logged messages.

The fix involves:
- Adding logic to redact sensitive information (e.g., replacing passwords with a placeholder like `"[REDACTED]"`).
- Ensuring that sensitive fields in JSON payloads are sanitized before logging.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
