### PR TITLE
Enable Python analysis indexing in VS Code settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -19,6 +19,8 @@
   "files.autoSave": "onFocusChange",
   "git.followTagsWhenSync": true,
   "python.analysis.autoFormatStrings": true,
+  "python.analysis.indexing": true,
+  "python.analysis.userFileIndexingLimit": -1,
   "python.analysis.autoImportCompletions": true,
   "python.analysis.completeFunctionParens": true,
   "python.analysis.diagnosticMode": "workspace",


### PR DESCRIPTION
## Summary
Updated VS Code Python analysis settings to enable indexing capabilities and remove file indexing limits for improved code intelligence and completion features.

## Key Changes
- Enabled `python.analysis.indexing` to activate Python code indexing
- Set `python.analysis.userFileIndexingLimit` to `-1` to remove file indexing limits and index all user files

## Details
These settings changes enhance the Python development experience in VS Code by:
- Enabling the indexing engine for better symbol resolution and code navigation
- Removing the default file limit restriction, allowing the analyzer to index the entire project without constraints
- Improving autocompletion and diagnostic accuracy across the workspace

https://claude.ai/code/session_01Wr5GFZwmbZ4qyTvLxa3TN1